### PR TITLE
Add feature for fast copying when creating parameterized GMSO structure

### DIFF
--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -124,14 +124,14 @@ class AtomType(ParametricPotential):
         """Return the SMARTS string of the atom_type."""
         return self.__dict__.get("definition_")
 
-    def clone(self):
+    def clone(self, fast_copy=False):
         """Clone this AtomType, faster alternative to deepcopying."""
         return AtomType(
             name=str(self.name),
             expression=None,
             parameters=None,
             independent_variables=None,
-            potential_expression=self.potential_expression_.clone(),
+            potential_expression=self.potential_expression_.clone(fast_copy),
             mass=u.unyt_quantity(self.mass_.value, self.mass_.units),
             charge=u.unyt_quantity(self.charge_.value, self.charge_.units),
             atomclass=self.atomclass_,

--- a/gmso/core/parametric_potential.py
+++ b/gmso/core/parametric_potential.py
@@ -176,7 +176,7 @@ class ParametricPotential(AbstractPotential):
 
         return params
 
-    def clone(self):
+    def clone(self, fast_copy=False):
         """Clone this parametric potential, faster alternative to deepcopying."""
         Creator = self.__class__
         kwargs = {"tags": deepcopy(self.tags_)}
@@ -192,7 +192,7 @@ class ParametricPotential(AbstractPotential):
 
         return Creator(
             name=self.name,
-            potential_expression=self.potential_expression_.clone(),
+            potential_expression=self.potential_expression_.clone(fast_copy),
             **kwargs,
         )
 

--- a/gmso/parameterization/parameterize.py
+++ b/gmso/parameterization/parameterize.py
@@ -19,6 +19,7 @@ def apply(
     assert_dihedral_params=True,
     assert_improper_params=False,
     remove_untyped=False,
+    fast_copy=True,
 ):
     """Set Topology parameter types from GMSO ForceFields.
 
@@ -72,6 +73,15 @@ def apply(
     remove_untyped : bool, optional, default=False
         If True, after the atomtyping and parameterization step, remove all connection
         that has no connection_type.
+
+    fast_copy : bool, optional, default=True
+        If True, sympy expressions and parameters will not be deep copied during replicated
+        parameterization. This can lead to the potentials for multiple sites/connections
+        to be changed if a single parameter_type independent variable or expression is
+        modified after the topology is parameterized. However, this leads to much faster
+        application of forcefield parameters, and so is defaulted to True. Note that
+        this should be changed to False if further modification of expressions are
+        necessary post parameterization.
     """
     config = TopologyParameterizationConfig.parse_obj(
         dict(
@@ -84,6 +94,7 @@ def apply(
             assert_dihedral_params=assert_dihedral_params,
             assert_improper_params=assert_improper_params,
             remove_untyped=remove_untyped,
+            fast_copy=True,
         )
     )
     parameterizer = TopologyParameterizer(

--- a/gmso/utils/expression.py
+++ b/gmso/utils/expression.py
@@ -306,21 +306,36 @@ class PotentialExpression:
 
         return indep_vars
 
-    def clone(self):
+    def clone(self, fast_copy=False):
         """Return a clone of this potential expression, faster alternative to deepcopying."""
-        return PotentialExpression(
-            deepcopy(self._expression),
-            deepcopy(self._independent_variables),
-            {
-                k: u.unyt_quantity(v.value, v.units)
-                if v.value.shape == ()
-                else u.unyt_array(v.value, v.units)
-                for k, v in self._parameters.items()
-            }
-            if self._is_parametric
-            else None,
-            verify_validity=False,
-        )
+        if not fast_copy:
+            return PotentialExpression(
+                deepcopy(self._expression),
+                deepcopy(self._independent_variables),
+                {
+                    k: u.unyt_quantity(v.value, v.units)
+                    if v.value.shape == ()
+                    else u.unyt_array(v.value, v.units)
+                    for k, v in self._parameters.items()
+                }
+                if self._is_parametric
+                else None,
+                verify_validity=False,
+            )
+        elif fast_copy:
+            return PotentialExpression(
+                self._expression,
+                self._independent_variables,
+                {
+                    k: u.unyt_quantity(v.value, v.units)
+                    if v.value.shape == ()
+                    else u.unyt_array(v.value, v.units)
+                    for k, v in self._parameters.items()
+                }
+                if self._is_parametric
+                else None,
+                verify_validity=False,
+            )
 
     @staticmethod
     def json(potential_expression):


### PR DESCRIPTION
This change adds an option in the gmso.parameterization.parameterize.apply() function to fast_copy for parametric potentials. This change gives a 5-100X speedup during parameterization, and as such is defaulted to True. This leverages the current clone() method in gmso/utils/expression.py for the PotentialExpression to not deepcopy the slow steps of this process, which are the sympy expression and sympy independent variables.

- [ ] Testing
- [ ] Approximately PEP8 compliant
- [ ] Feedback