### PR TITLE
Add testing for hierarchical Structures

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -8,7 +8,7 @@ import unyt as u
 from boltons.setutils import IndexedSet
 
 import gmso
-from gmso.abc.abstract_site import MoleculeType, ResidueType, Site
+from gmso.abc.abstract_site import Site
 from gmso.core.angle import Angle
 from gmso.core.angle_type import AngleType
 from gmso.core.atom import Atom

--- a/gmso/parameterization/molecule_utils.py
+++ b/gmso/parameterization/molecule_utils.py
@@ -1,5 +1,4 @@
 """Utilities for application of a particular forcefield to a molecule."""
-from gmso.abc.abstract_site import MoleculeType, ResidueType
 
 
 def _conn_in_molecule(connection, label, is_group=False):

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -316,7 +316,7 @@ class TopologyParameterizer(GMSOBase):
             for label in labels:
                 if label not in self.forcefields:
                     warnings.warn(
-                        f"Group {group} will not be parameterized, as the forcefield to parameterize it "
+                        f"Group {label} will not be parameterized, as the forcefield to parameterize it "
                         f"is missing."
                     )  # FixMe: Will warning be enough?
                 else:

--- a/gmso/tests/parameterization/test_parameterization_options.py
+++ b/gmso/tests/parameterization/test_parameterization_options.py
@@ -1,4 +1,5 @@
 import random
+from copy import deepcopy
 
 import forcefield_utilities as ffutils
 import mbuild as mb
@@ -8,11 +9,13 @@ from foyer.exceptions import FoyerError
 import gmso
 from gmso.core.forcefield import ForceField
 from gmso.core.topology import Topology
+from gmso.external.convert_mbuild import from_mbuild
 from gmso.parameterization.parameterize import apply
 from gmso.parameterization.topology_parameterizer import ParameterizationError
 from gmso.tests.parameterization.parameterization_base_test import (
     ParameterizationBaseTest,
 )
+from gmso.tests.utils import get_path
 
 
 class TestParameterizationOptions(ParameterizationBaseTest):
@@ -216,3 +219,43 @@ class TestParameterizationOptions(ParameterizationBaseTest):
             use_molecule_info=True,
         )
         assert ethane_box_with_methane.atom_types is not None
+
+    @pytest.mark.parametrize(
+        "identify_connected_components, use_molecule_info, match_ff_by",
+        [
+            (False, False, "group"),
+            (True, False, "group"),
+            (False, True, "group"),
+            (True, True, "group"),
+            (False, False, "molecule"),
+            (True, False, "molecule"),
+            (False, True, "molecule"),
+            (True, True, "molecule"),
+        ],
+    )
+    def test_hierarchical_mol_structure(
+        self,
+        oplsaa_gmso,
+        hierarchical_top,
+        identify_connected_components,
+        use_molecule_info,
+        match_ff_by,
+    ):
+        top = deepcopy(hierarchical_top)
+        # Load forcefield dicts
+        tip3p = ForceField(get_path("tip3p.xml"))
+        if match_ff_by == "molecule":
+            ff_dict = {
+                "polymer": oplsaa_gmso,
+                "cyclopentane": oplsaa_gmso,
+                "water": tip3p,
+            }
+        elif match_ff_by == "group":
+            ff_dict = {"sol1": oplsaa_gmso, "sol2": tip3p}
+        apply(
+            top,
+            ff_dict,
+            identify_connected_components=identify_connected_components,
+            use_molecule_info=use_molecule_info,
+            match_ff_by=match_ff_by,
+        )

--- a/gmso/tests/test_convert_mbuild.py
+++ b/gmso/tests/test_convert_mbuild.py
@@ -164,3 +164,13 @@ class TestConvertMBuild(BaseTest):
         compound = mb.load("CCOC", smiles=True)
         top = from_mbuild(compound)
         assert top.name is not None
+
+    def test_hierarchical_structure(self, hierarchical_top):
+        for label in ("polymer", "water", "cyclopentane"):
+            assert label in hierarchical_top.unique_site_labels(
+                "molecule", name_only=True
+            )
+        for label in ("sol1", "sol2"):
+            assert label in hierarchical_top.unique_site_labels(
+                "group", name_only=True
+            )


### PR DESCRIPTION
This PR should add a few unyt tests for a fixture of an mBuild structure with layers between the group and molecule name. It also applies forcefields based on those molecule names.